### PR TITLE
Implement subscription billing with validation modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# rob
+# Subscription Billing Demo
+
+This repository demonstrates subscription handling for Android and iOS.
+
+## Android
+- Uses Google Play Billing library for purchasing and restoring subscriptions.
+- `BillingManager` wraps `BillingClient` to initiate purchases and query existing subscriptions.
+- `SubscriptionStatusActivity` shows subscription expiry and allows restoring purchases.
+
+## iOS
+- Implements StoreKit 2 with a fallback legacy manager using StoreKit 1.
+- `SubscriptionView` provides a simple UI with a *Restore Purchases* button.
+
+## Validation
+- `ValidationService` sends purchase tokens or receipts to a backend endpoint for validation.
+
+These modules are stubs and intended for demonstration purposes.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    compileSdk 33
+
+    defaultConfig {
+        applicationId "com.example.billingapp"
+        minSdk 21
+        targetSdk 33
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation "com.android.billingclient:billing-ktx:6.0.1"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.0"
+}

--- a/android/src/main/java/com/example/billing/BillingManager.kt
+++ b/android/src/main/java/com/example/billing/BillingManager.kt
@@ -1,0 +1,72 @@
+package com.example.billing
+
+import android.app.Activity
+import android.content.Context
+import com.android.billingclient.api.*
+
+/**
+ * Simple wrapper around [BillingClient] to handle subscription purchase and restore.
+ */
+class BillingManager(private val context: Context) : PurchasesUpdatedListener {
+    private val billingClient: BillingClient = BillingClient.newBuilder(context)
+        .setListener(this)
+        .enablePendingPurchases()
+        .build()
+
+    fun startConnection(onReady: () -> Unit) {
+        billingClient.startConnection(object : BillingClientStateListener {
+            override fun onBillingSetupFinished(result: BillingResult) {
+                if (result.responseCode == BillingClient.BillingResponseCode.OK) {
+                    onReady()
+                }
+            }
+
+            override fun onBillingServiceDisconnected() {
+                // Retry or notify user
+            }
+        })
+    }
+
+    fun purchase(activity: Activity, productId: String) {
+        val params = BillingFlowParams.newBuilder()
+            .setProductDetailsParamsList(
+                listOf(
+                    BillingFlowParams.ProductDetailsParams.newBuilder()
+                        .setProductDetails(
+                            queryProduct(productId) ?: return
+                        )
+                        .build()
+                )
+            )
+            .build()
+        billingClient.launchBillingFlow(activity, params)
+    }
+
+    private fun queryProduct(productId: String): ProductDetails? {
+        val params = QueryProductDetailsParams.newBuilder()
+            .setProductList(
+                listOf(
+                    QueryProductDetailsParams.Product.newBuilder()
+                        .setProductId(productId)
+                        .setProductType(BillingClient.ProductType.SUBS)
+                        .build()
+                )
+            ).build()
+        val result = billingClient.queryProductDetails(params)
+        return result.productDetailsList?.firstOrNull()
+    }
+
+    fun restorePurchases(onResult: (List<Purchase>) -> Unit) {
+        billingClient.queryPurchasesAsync(
+            QueryPurchasesParams.newBuilder().setProductType(BillingClient.ProductType.SUBS).build()
+        ) { _, purchases ->
+            onResult(purchases)
+        }
+    }
+
+    override fun onPurchasesUpdated(result: BillingResult, purchases: MutableList<Purchase>?) {
+        if (result.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
+            // Handle purchased items
+        }
+    }
+}

--- a/android/src/main/java/com/example/billing/SubscriptionStatusActivity.kt
+++ b/android/src/main/java/com/example/billing/SubscriptionStatusActivity.kt
@@ -1,0 +1,36 @@
+package com.example.billing
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import java.text.SimpleDateFormat
+import java.util.*
+
+/**
+ * Simple screen showing subscription expiry date and option to manage.
+ */
+class SubscriptionStatusActivity : AppCompatActivity() {
+    private val billingManager = BillingManager(this)
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_subscription_status)
+
+        val expiryView: TextView = findViewById(R.id.subscription_expiry)
+        val restoreButton: Button = findViewById(R.id.restore_button)
+
+        restoreButton.setOnClickListener {
+            billingManager.restorePurchases { purchases ->
+                val expiry = purchases.firstOrNull()?.expiryTime
+                runOnUiThread {
+                    expiryView.text = expiry?.let { dateFormat.format(Date(it)) } ?: "Not subscribed"
+                }
+            }
+        }
+    }
+}
+
+val Purchase.expiryTime: Long?
+    get() = this.accountIdentifiers?.obfuscatedAccountId?.toLongOrNull()

--- a/android/src/main/res/layout/activity_subscription_status.xml
+++ b/android/src/main/res/layout/activity_subscription_status.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/subscription_expiry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Expiry:"
+        android:textSize="18sp" />
+
+    <Button
+        android:id="@+id/restore_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Restore" />
+</LinearLayout>

--- a/ios/PurchaseManager.swift
+++ b/ios/PurchaseManager.swift
@@ -1,0 +1,49 @@
+import Foundation
+import StoreKit
+
+/// Manages in-app purchases with StoreKit 2 and falls back to StoreKit 1 when necessary.
+@available(iOS 15.0, *)
+class PurchaseManager: ObservableObject {
+    @Published var lastTransaction: Transaction?
+
+    func purchase(productId: String) async throws {
+        guard let product = try await Product.products(for: [productId]).first else { return }
+        let result = try await product.purchase()
+        switch result {
+        case .success(let verification):
+            if case .verified(let transaction) = verification {
+                await transaction.finish()
+                DispatchQueue.main.async { self.lastTransaction = transaction }
+            }
+        default: break
+        }
+    }
+
+    func restore() async {
+        for await result in Transaction.currentEntitlements {
+            if case .verified(let transaction) = result {
+                DispatchQueue.main.async { self.lastTransaction = transaction }
+            }
+        }
+    }
+}
+
+/// Legacy implementation for iOS 14 and below using StoreKit 1.
+class LegacyPurchaseManager: NSObject, SKPaymentTransactionObserver {
+    @Published var lastTransaction: SKPaymentTransaction?
+
+    func purchase(productId: String) {
+        SKPaymentQueue.default().add(self)
+        let payment = SKPayment(product: SKProduct())
+        SKPaymentQueue.default().add(payment)
+    }
+
+    func restore() {
+        SKPaymentQueue.default().add(self)
+        SKPaymentQueue.default().restoreCompletedTransactions()
+    }
+
+    func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
+        lastTransaction = transactions.first
+    }
+}

--- a/ios/ReceiptValidator.swift
+++ b/ios/ReceiptValidator.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct ValidationResponse: Decodable { let success: Bool }
+
+enum ReceiptValidator {
+    static func validate(receiptData: Data) async throws -> Bool {
+        var request = URLRequest(url: URL(string: "https://example.com/api/validate/ios")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["receipt": receiptData.base64EncodedString()])
+        let (data, _) = try await URLSession.shared.data(for: request)
+        return try JSONDecoder().decode(ValidationResponse.self, from: data).success
+    }
+}

--- a/ios/SubscriptionView.swift
+++ b/ios/SubscriptionView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import StoreKit
+
+struct SubscriptionView: View {
+    @StateObject private var manager = PurchaseManager()
+    @State private var expiryText = ""
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Subscription expires: \(expiryText)")
+            Button("Restore Purchases") {
+                Task { await manager.restore(); updateExpiry() }
+            }
+        }
+        .onAppear { updateExpiry() }
+    }
+
+    private func updateExpiry() {
+        if let transaction = manager.lastTransaction {
+            let date = transaction.expirationDate ?? Date()
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            expiryText = formatter.string(from: date)
+        } else {
+            expiryText = "Unknown"
+        }
+    }
+}

--- a/validation/ValidationService.kt
+++ b/validation/ValidationService.kt
@@ -1,0 +1,38 @@
+package com.example.validation
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import org.json.JSONObject
+
+/**
+ * Sends purchase tokens/receipts to backend for validation.
+ */
+object ValidationService {
+    @Throws(Exception::class)
+    fun validateAndroidPurchase(purchaseToken: String): Boolean {
+        val url = URL("https://example.com/api/validate/android")
+        val connection = (url.openConnection() as HttpURLConnection).apply {
+            requestMethod = "POST"
+            doOutput = true
+            setRequestProperty("Content-Type", "application/json")
+            outputStream.use { it.write("{""token"":""$purchaseToken""}".toByteArray()) }
+        }
+        val response = connection.inputStream.bufferedReader().use(BufferedReader::readText)
+        return JSONObject(response).optBoolean("success")
+    }
+
+    @Throws(Exception::class)
+    fun validateIosReceipt(receipt: String): Boolean {
+        val url = URL("https://example.com/api/validate/ios")
+        val connection = (url.openConnection() as HttpURLConnection).apply {
+            requestMethod = "POST"
+            doOutput = true
+            setRequestProperty("Content-Type", "application/json")
+            outputStream.use { it.write("{""receipt"":""$receipt""}".toByteArray()) }
+        }
+        val response = connection.inputStream.bufferedReader().use(BufferedReader::readText)
+        return JSONObject(response).optBoolean("success")
+    }
+}


### PR DESCRIPTION
## Summary
- Add Android billing setup with purchase and restore helpers
- Introduce iOS StoreKit 2 manager with StoreKit 1 fallback
- Provide validation service for sending purchase tokens/receipts to backend

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68967b9d938883299c287f657a5812ab