### PR TITLE
Add server configuration sync utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # rob
+
+Utility script that synchronizes a server configuration list with a backend.
+
+- After subscription confirmation, `config_sync.py` requests the server list
+  and stores it locally in `servers.json`.
+- Configuration is refreshed on application start and then periodically on a
+  schedule (daily by default).
+- Optionally, push notifications can be received via WebSocket to trigger
+  immediate synchronization.
+
+Run `python -m py_compile config_sync.py` to verify syntax.

--- a/config_sync.py
+++ b/config_sync.py
@@ -1,0 +1,61 @@
+import json
+import sched
+import time
+from threading import Thread, Event
+
+import requests
+
+SERVERS_FILE = "servers.json"
+BACKEND_URL = "https://example.com/api/servers"
+
+def fetch_servers():
+    """Fetch list of servers from backend and store locally."""
+    response = requests.get(BACKEND_URL, timeout=10)
+    response.raise_for_status()
+    servers = response.json()
+    with open(SERVERS_FILE, "w", encoding="utf-8") as f:
+        json.dump(servers, f)
+
+
+def confirm_subscription():
+    """Call after subscription confirmation to sync server list."""
+    fetch_servers()
+
+
+def update_configuration(interval_hours: int = 24):
+    """Update configuration at app start and schedule periodic updates."""
+    scheduler = sched.scheduler(time.time, time.sleep)
+
+    def _periodic():
+        fetch_servers()
+        scheduler.enter(interval_hours * 3600, 1, _periodic)
+
+    _periodic()
+    Thread(target=scheduler.run, daemon=True).start()
+    return scheduler
+
+
+def start_push_listener(url: str, stop_event: Event | None = None):
+    """Listen for push notifications to trigger immediate sync (optional)."""
+    try:
+        import websocket  # type: ignore
+    except ImportError:  # pragma: no cover - optional dependency
+        print("websocket-client not installed; push notifications disabled")
+        return None
+
+    def on_message(ws, message):  # pragma: no cover - network dependent
+        fetch_servers()
+
+    ws = websocket.WebSocketApp(url, on_message=on_message)
+    thread = Thread(target=ws.run_forever, daemon=True)
+    thread.start()
+    if stop_event:
+        stop_event.wait()
+        ws.close()
+    return ws
+
+
+if __name__ == "__main__":
+    # Example usage: sync immediately and schedule periodic refreshes.
+    confirm_subscription()
+    update_configuration()


### PR DESCRIPTION
## Summary
- add `config_sync.py` to request server lists after subscription, refresh config on start or schedule, and optionally listen for push notifications
- document usage and features in README

## Testing
- `python -m py_compile config_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68967bc0e4448329859f9c5a45b7b1f6