### PR TITLE
Add map-based server selection with fallback lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# rob
+# Server Map Demo
+
+This repository contains reference implementations for displaying up to ten
+server locations for Europe and the United States on mobile platforms.
+
+- **Android** uses the Google Maps SDK to plot server markers. Selecting a
+  marker reveals the server name and a Connect button. If the map cannot be
+  displayed, a fallback list of servers is shown instead.
+- **iOS** uses MapKit with similar functionality and the same fallback list
+  when the map fails to load.
+
+Both examples include a hard-coded list of ten server locations and basic
+connect prompts. Networking logic for actual connections should be added as
+needed.

--- a/android/MainActivity.kt
+++ b/android/MainActivity.kt
@@ -1,0 +1,89 @@
+package com.example.rob
+
+import android.os.Bundle
+import android.widget.ArrayAdapter
+import android.widget.ListView
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.MapsInitializer
+import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MarkerOptions
+
+/**
+ * Displays up to ten server locations on a Google Map. Selecting a marker
+ * shows the server name and offers a Connect button. If the map is not
+ * available (e.g. missing services or network), a fallback list view of
+ * servers is displayed instead.
+ */
+class MainActivity : AppCompatActivity(), com.google.android.gms.maps.OnMapReadyCallback {
+
+    data class Server(val name: String, val location: LatLng)
+
+    private val servers = listOf(
+        Server("Berlin", LatLng(52.5200, 13.4050)),
+        Server("London", LatLng(51.5074, -0.1278)),
+        Server("Paris", LatLng(48.8566, 2.3522)),
+        Server("Amsterdam", LatLng(52.3676, 4.9041)),
+        Server("Warsaw", LatLng(52.2297, 21.0122)),
+        Server("New York", LatLng(40.7128, -74.0060)),
+        Server("San Francisco", LatLng(37.7749, -122.4194)),
+        Server("Chicago", LatLng(41.8781, -87.6298)),
+        Server("Dallas", LatLng(32.7767, -96.7970)),
+        Server("Miami", LatLng(25.7617, -80.1918))
+    )
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        try {
+            MapsInitializer.initialize(this)
+            val fragment = SupportMapFragment.newInstance()
+            supportFragmentManager.beginTransaction()
+                .replace(android.R.id.content, fragment)
+                .commit()
+            fragment.getMapAsync(this)
+        } catch (e: Exception) {
+            showServerList()
+        }
+    }
+
+    override fun onMapReady(map: GoogleMap) {
+        map.uiSettings.isZoomControlsEnabled = true
+        servers.forEach { server ->
+            map.addMarker(
+                MarkerOptions()
+                    .position(server.location)
+                    .title(server.name)
+            )
+        }
+        map.moveCamera(CameraUpdateFactory.newLatLngZoom(servers.first().location, 2f))
+        map.setOnMarkerClickListener { marker ->
+            AlertDialog.Builder(this)
+                .setTitle(marker.title)
+                .setMessage("Connect to ${marker.title}?")
+                .setPositiveButton("Connect", null)
+                .setNegativeButton("Cancel", null)
+                .show()
+            true
+        }
+    }
+
+    private fun showServerList() {
+        val listView = ListView(this)
+        val names = servers.map { it.name }
+        listView.adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, names)
+        listView.setOnItemClickListener { _, _, position, _ ->
+            val server = servers[position]
+            AlertDialog.Builder(this)
+                .setTitle(server.name)
+                .setMessage("Connect to ${server.name}?")
+                .setPositiveButton("Connect", null)
+                .setNegativeButton("Cancel", null)
+                .show()
+        }
+        setContentView(listView)
+    }
+}
+

--- a/ios/ViewController.swift
+++ b/ios/ViewController.swift
@@ -1,0 +1,91 @@
+import UIKit
+import MapKit
+
+/// Shows up to ten server locations on an Apple Map. Selecting a pin
+/// displays the server name and a Connect button. If the map fails to
+/// load, a table view listing all servers is used instead.
+class ViewController: UIViewController, MKMapViewDelegate, UITableViewDataSource, UITableViewDelegate {
+    struct Server {
+        let name: String
+        let coordinate: CLLocationCoordinate2D
+    }
+
+    private let servers: [Server] = [
+        Server(name: "Berlin", coordinate: CLLocationCoordinate2D(latitude: 52.5200, longitude: 13.4050)),
+        Server(name: "London", coordinate: CLLocationCoordinate2D(latitude: 51.5074, longitude: -0.1278)),
+        Server(name: "Paris", coordinate: CLLocationCoordinate2D(latitude: 48.8566, longitude: 2.3522)),
+        Server(name: "Amsterdam", coordinate: CLLocationCoordinate2D(latitude: 52.3676, longitude: 4.9041)),
+        Server(name: "Warsaw", coordinate: CLLocationCoordinate2D(latitude: 52.2297, longitude: 21.0122)),
+        Server(name: "New York", coordinate: CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.0060)),
+        Server(name: "San Francisco", coordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194)),
+        Server(name: "Chicago", coordinate: CLLocationCoordinate2D(latitude: 41.8781, longitude: -87.6298)),
+        Server(name: "Dallas", coordinate: CLLocationCoordinate2D(latitude: 32.7767, longitude: -96.7970)),
+        Server(name: "Miami", coordinate: CLLocationCoordinate2D(latitude: 25.7617, longitude: -80.1918))
+    ]
+
+    private let mapView = MKMapView()
+    private let tableView = UITableView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        mapView.delegate = self
+        tableView.dataSource = self
+        tableView.delegate = self
+
+        view.addSubview(mapView)
+        mapView.frame = view.bounds
+
+        for server in servers {
+            let annotation = MKPointAnnotation()
+            annotation.title = server.name
+            annotation.coordinate = server.coordinate
+            mapView.addAnnotation(annotation)
+        }
+    }
+
+    // MARK: - MKMapViewDelegate
+    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        let view = MKPinAnnotationView(annotation: annotation, reuseIdentifier: nil)
+        view.canShowCallout = true
+        view.rightCalloutAccessoryView = UIButton(type: .detailDisclosure)
+        return view
+    }
+
+    func mapView(_ mapView: MKMapView, annotationView view: MKAnnotationView, calloutAccessoryControlTapped control: UIControl) {
+        guard let name = view.annotation?.title ?? nil else { return }
+        let alert = UIAlertController(title: name, message: "Connect to \(name)?", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Connect", style: .default))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
+
+    func mapViewDidFailLoadingMap(_ mapView: MKMapView, withError error: Error) {
+        mapView.removeFromSuperview()
+        showServerList()
+    }
+
+    // MARK: - Fallback list
+    private func showServerList() {
+        tableView.frame = view.bounds
+        view.addSubview(tableView)
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return servers.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        cell.textLabel?.text = servers[indexPath.row].name
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let server = servers[indexPath.row]
+        let alert = UIAlertController(title: server.name, message: "Connect to \(server.name)?", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Connect", style: .default))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
+}
+


### PR DESCRIPTION
## Summary
- use Google Maps on Android to show up to ten server markers with connect prompts and a fallback list
- use MapKit on iOS with the same server list and fallback behaviour

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68967cd5789483299c40ae40524d9a3f