### PR TITLE
Add VPN UI design guidelines and assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # rob
+
+Design assets and guidelines for VPN app.

--- a/assets/icons/connect.svg
+++ b/assets/icons/connect.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 2v10" stroke="#17A2B8" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="12" cy="13" r="9" stroke="#17A2B8" stroke-width="2" fill="none"/>
+</svg>

--- a/assets/icons/settings.svg
+++ b/assets/icons/settings.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="3" stroke="#17A2B8" stroke-width="2"/>
+  <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" stroke="#17A2B8" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,6 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="32" cy="32" r="30" fill="#F5C156" stroke="#17A2B8" stroke-width="4"/>
+  <circle cx="24" cy="24" r="6" fill="#F5C156" stroke="#17A2B8" stroke-width="4"/>
+  <circle cx="40" cy="24" r="6" fill="#F5C156" stroke="#17A2B8" stroke-width="4"/>
+  <path d="M20 40 C24 44 40 44 44 40" stroke="#17A2B8" stroke-width="4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,45 @@
+# UI Design Guidelines for VPN App
+
+## Main Screen
+- A large, centered **"Подключить VPN"** button occupies the primary focus.
+- Below the button, display connection status (`Не подключено`/`Подключено`).
+- Keep navigation minimal: top app bar with the logo on the left and a settings icon on the right.
+
+## Themes
+
+### Android (MaterialTheme)
+- Define light and dark color palettes in `values/colors.xml` and `values-night/colors.xml`.
+- Use `Theme.VPNApp` inheriting from `Material3`.
+- Sample `themes.xml` snippet:
+  ```xml
+  <!-- values/themes.xml -->
+  <style name="Theme.VPNApp" parent="Theme.Material3.Light.NoActionBar">
+      <item name="colorPrimary">@color/teal_200</item>
+      <item name="colorSecondary">@color/amber_200</item>
+  </style>
+  <!-- values-night/themes.xml -->
+  <style name="Theme.VPNApp" parent="Theme.Material3.Dark.NoActionBar">
+      <item name="colorPrimary">@color/teal_200</item>
+      <item name="colorSecondary">@color/amber_200</item>
+  </style>
+  ```
+
+### iOS (UIColor + UITraitCollection)
+- Provide light and dark `UIColor` assets.
+- Switch colors when `traitCollection.userInterfaceStyle` changes:
+  ```swift
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+      super.traitCollectionDidChange(previousTraitCollection)
+      view.backgroundColor = UIColor(named: "Background")
+  }
+  ```
+
+## Branding
+- Logo and icons follow a friendly outline style inspired by Outline/TunnelBear.
+- Suggested palette: teal (#17a2b8), soft yellow (#f5c156), warm gray (#f2f2f2).
+- Logo concept: simple bear or shield outline with smooth curves.
+- Store assets under `assets/logo.png`, `assets/icons/` (placeholders for now).
+
+## Resources
+- Mockups can be produced in Figma using these guidelines.
+- Ensure controls remain accessible and legible in both themes.


### PR DESCRIPTION
## Summary
- Create UI design doc with large "Подключить VPN" button, minimalist navigation, and theme setup for Android MaterialTheme and iOS UIColor + UITraitCollection
- Add outline-inspired logo and icons based on Outline/TunnelBear style

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68967cdfbe10832988f77afc9d36bb84